### PR TITLE
fix(billing): skip batchPut if no space diff

### DIFF
--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -99,6 +99,11 @@ export const storeSpaceUsageDeltas = async (deltas, ctx) => {
     spaceDiffs.push(...res.ok)
   }
 
+  if (spaceDiffs.length === 0) return {
+    ok: 'no space diffs to store',
+    error: undefined
+  }
+
   return ctx.spaceDiffStore.batchPut(spaceDiffs)
 }
 

--- a/billing/test/lib/ucan-stream.js
+++ b/billing/test/lib/ucan-stream.js
@@ -229,7 +229,7 @@ export const test = {
 
     const deltas = findSpaceUsageDeltas(receipts)
     const storeDeltasRes = await storeSpaceUsageDeltas(deltas, ctx)
-    assert.equal(storeDeltasRes.error?.name, 'InsufficientRecords')
+    assert.equal(storeDeltasRes.ok, 'no space diffs to store')
 
     const res = await ctx.spaceDiffStore.list({
       provider: consumer.provider,


### PR DESCRIPTION
Issue: https://github.com/storacha/project-tracking/issues/185

Potential Fix: if there are no records for that `.list({consumer: delta.resource})` in the `consumerStore`, it will return an empty array, then it won't generate any space diff to be stored, and it will throw the error when we execute the `batchPut` call. The fix skips the `batchPut` call when no diffs are available.