### PR TITLE
feat: capture x-client header for analytics

### DIFF
--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -91,6 +91,17 @@ const codec = Codec.inbound({
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request
  */
 export async function ucanInvocationRouter(request) {
+  // Capture X-Client custom header for analytics - ignore if not present
+  const clientId = request.headers['X-Client']
+  if (clientId) {
+    console.log(JSON.stringify({
+      message: 'Client request',
+      clientId,
+      requestId: request.requestContext?.requestId || 'unknown',
+      timestamp: new Date().toISOString()
+    }))
+  }
+
   const {
     uploadTableName,
     blobRegistryTableName,


### PR DESCRIPTION
### Context
We recently added the ability to pass custom headers to identify which Storacha client uses the Upload API (see: https://github.com/storacha/upload-service/pull/215). Now we need to capture the custom header for analytics.

### Changes
- Updated the `ucan-invocation-handler` to log additional information if the `X-Client` custom header is present. 
- The logs are structured in JSON format that's easy to query in CloudWatch Logs.
- The `clientId` field will contain the actual value of the `X-Client` header which indicates the name and version of the Storacha Client + service/project it is integrated to, e.g: `Storacha/X (js; MCP/Y)` - where `X` =  major version of the Storacha Client, and `Y` =  major version of the service/project integration.
- The `requestId` allows us to correlate this specific log entry with other logs from the same request, which helps debug issues.
- Then we build analytics based on CloudWatch Logs Insights using some query like this:
   ```
   fields @timestamp, clientId
   | filter message = "Client request"
   | stats count(*) as requestCount by clientId
   | sort requestCount desc
   ```

Related to: https://github.com/storacha/mcp-storage-server/issues/18